### PR TITLE
fix: upgrade awilix-router-core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@koa/router": "^15.3.0",
-        "awilix-router-core": "^3.0.0",
+        "awilix-router-core": "^4.0.0",
         "koa-compose": "^4.1.0"
       },
       "devDependencies": {
@@ -29,7 +29,7 @@
         "@types/prettier": "^3.0.0",
         "@types/rimraf": "^4.0.5",
         "assert-request": "^1.0.6",
-        "awilix": "^12.0.5",
+        "awilix": "^12.1.0",
         "babel-core": "^7.0.0-bridge.0",
         "babel-jest": "^30.2.0",
         "coveralls": "^3.1.1",
@@ -48,7 +48,7 @@
         "typescript-eslint": "^8.54.0"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -5346,13 +5346,12 @@
       "dev": true
     },
     "node_modules/awilix": {
-      "version": "12.0.5",
-      "resolved": "https://registry.npmjs.org/awilix/-/awilix-12.0.5.tgz",
-      "integrity": "sha512-Qf/V/hRo6DK0FoBKJ9QiObasRxHAhcNi0mV6kW2JMawxS3zq6Un+VsZmVAZDUfvB+MjTEiJ2tUJUl4cr0JiUAw==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/awilix/-/awilix-12.1.0.tgz",
+      "integrity": "sha512-9ZgF5IHQQvvpgKasxNU2WAzQLVKmRBwjEm8zksqPxtAdrmmCRMVjIgeOTr/kOE4O9EcUXl/qRbtjXh8ucV0CkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "camel-case": "^4.1.2",
         "fast-glob": "^3.3.3"
       },
       "engines": {
@@ -5360,15 +5359,15 @@
       }
     },
     "node_modules/awilix-router-core": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/awilix-router-core/-/awilix-router-core-3.0.0.tgz",
-      "integrity": "sha512-28P0OsJtpnPklnZLhr/OsQ4yEyyyMyGsRrt7HOVn9judCi6qA1pqByseUWLNmrWnjFPwIrZf9b7BhgGwoeCsqQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/awilix-router-core/-/awilix-router-core-4.0.0.tgz",
+      "integrity": "sha512-APgJgSkCvl/jU9uMTl4PwH5l7yU4XarPlSYia9qQZ32qhzO9OwiRJEeKL7hBRdiJJ7MvOzVm1cUw2jFbHJwYMA==",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.3"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/aws-sign2": {
@@ -5746,16 +5745,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/camel-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
-      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-      "dev": true,
-      "dependencies": {
-        "pascal-case": "^3.1.2",
-        "tslib": "^2.0.3"
       }
     },
     "node_modules/camelcase": {
@@ -10948,15 +10937,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/lower-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -11352,16 +11332,6 @@
       "integrity": "sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/no-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "dev": true,
-      "dependencies": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
-      }
     },
     "node_modules/node-emoji": {
       "version": "2.2.0",
@@ -13900,16 +13870,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/pascal-case": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "dev": true,
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
       }
     },
     "node_modules/path-exists": {
@@ -20253,19 +20213,18 @@
       "dev": true
     },
     "awilix": {
-      "version": "12.0.5",
-      "resolved": "https://registry.npmjs.org/awilix/-/awilix-12.0.5.tgz",
-      "integrity": "sha512-Qf/V/hRo6DK0FoBKJ9QiObasRxHAhcNi0mV6kW2JMawxS3zq6Un+VsZmVAZDUfvB+MjTEiJ2tUJUl4cr0JiUAw==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/awilix/-/awilix-12.1.0.tgz",
+      "integrity": "sha512-9ZgF5IHQQvvpgKasxNU2WAzQLVKmRBwjEm8zksqPxtAdrmmCRMVjIgeOTr/kOE4O9EcUXl/qRbtjXh8ucV0CkQ==",
       "dev": true,
       "requires": {
-        "camel-case": "^4.1.2",
         "fast-glob": "^3.3.3"
       }
     },
     "awilix-router-core": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/awilix-router-core/-/awilix-router-core-3.0.0.tgz",
-      "integrity": "sha512-28P0OsJtpnPklnZLhr/OsQ4yEyyyMyGsRrt7HOVn9judCi6qA1pqByseUWLNmrWnjFPwIrZf9b7BhgGwoeCsqQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/awilix-router-core/-/awilix-router-core-4.0.0.tgz",
+      "integrity": "sha512-APgJgSkCvl/jU9uMTl4PwH5l7yU4XarPlSYia9qQZ32qhzO9OwiRJEeKL7hBRdiJJ7MvOzVm1cUw2jFbHJwYMA==",
       "requires": {
         "fast-glob": "^3.3.3"
       }
@@ -20540,16 +20499,6 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
-    },
-    "camel-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
-      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-      "dev": true,
-      "requires": {
-        "pascal-case": "^3.1.2",
-        "tslib": "^2.0.3"
-      }
     },
     "camelcase": {
       "version": "5.3.1",
@@ -24083,15 +24032,6 @@
         }
       }
     },
-    "lower-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.0.3"
-      }
-    },
     "lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -24348,16 +24288,6 @@
       "resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
       "integrity": "sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==",
       "dev": true
-    },
-    "no-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "dev": true,
-      "requires": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
-      }
     },
     "node-emoji": {
       "version": "2.2.0",
@@ -26034,16 +25964,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
-    },
-    "pascal-case": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "dev": true,
-      "requires": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
     },
     "path-exists": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "homepage": "https://github.com/jeffijoe/awilix-koa#readme",
   "dependencies": {
     "@koa/router": "^15.3.0",
-    "awilix-router-core": "^3.0.0",
+    "awilix-router-core": "^4.0.0",
     "koa-compose": "^4.1.0"
   },
   "devDependencies": {
@@ -64,7 +64,7 @@
     "@types/prettier": "^3.0.0",
     "@types/rimraf": "^4.0.5",
     "assert-request": "^1.0.6",
-    "awilix": "^12.0.5",
+    "awilix": "^12.1.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^30.2.0",
     "coveralls": "^3.1.1",


### PR DESCRIPTION
## Summary
- Upgrades `awilix-router-core` from v3 to v4 and `awilix` to latest
- Fixes an issue where ARC was importing fast-glob in a way not compatible with ESM, but worked with TypeScript's ESM interop